### PR TITLE
feat: Add `ToprfRecoveryDetails` to SeedlessOnboarding Controller state

### DIFF
--- a/packages/seedless-onboarding-controller/src/errors.ts
+++ b/packages/seedless-onboarding-controller/src/errors.ts
@@ -5,7 +5,6 @@ import {
 } from '@metamask/toprf-secure-backup';
 
 import { SeedlessOnboardingControllerError } from './constants';
-import type { ToprfRecoveryDetails } from './types';
 
 /**
  * Get the error message from the TOPRF error code.
@@ -109,21 +108,6 @@ export class RecoveryError extends Error {
     }
     return new RecoveryError(
       SeedlessOnboardingControllerError.LoginFailedError,
-    );
-  }
-
-  /**
-   * Get an instance of the RecoveryError class for too many login attempts.
-   *
-   * @param errorData - The error data to get the instance of.
-   * @returns The instance of the RecoveryError class.
-   */
-  static getTooManyLoginAttemptsError(
-    errorData: RateLimitErrorData,
-  ): RecoveryError {
-    return new RecoveryError(
-      SeedlessOnboardingControllerError.TooManyLoginAttempts,
-      errorData,
     );
   }
 

--- a/packages/seedless-onboarding-controller/src/index.ts
+++ b/packages/seedless-onboarding-controller/src/index.ts
@@ -13,6 +13,7 @@ export type {
   SeedlessOnboardingControllerActions,
   SeedlessOnboardingControllerEvents,
   ToprfKeyDeriver,
+  ToprfRecoveryDetails,
 } from './types';
 export {
   Web3AuthNetwork,

--- a/packages/seedless-onboarding-controller/src/types.ts
+++ b/packages/seedless-onboarding-controller/src/types.ts
@@ -65,6 +65,21 @@ export type SRPBackedUpUserDetails = {
   authPubKey: string;
 };
 
+/**
+ * TOPRF Recovery attempt details.
+ */
+export type ToprfRecoveryDetails = {
+  /**
+   * The number of attempts made to recover the password.
+   */
+  numberOfAttempts: number;
+
+  /**
+   * The remaining time in seconds to wait before the next attempt to recover the password.
+   */
+  remainingTime: number;
+};
+
 // State
 export type SeedlessOnboardingControllerState =
   Partial<AuthenticatedUserDetails> &
@@ -96,6 +111,11 @@ export type SeedlessOnboardingControllerState =
        * Cache for checkIsPasswordOutdated result and timestamp.
        */
       passwordOutdatedCache?: { isExpiredPwd: boolean; timestamp: number };
+
+      /**
+       * Details about the TOPRF recovery process.
+       */
+      toprfRecoveryDetails: ToprfRecoveryDetails;
     };
 
 // Actions


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
Currently to prevent bruteforce, after 4th recovery attempt failure, the users will be blocked for some delay period before the retry. The delay period value is returned from the server and the mapping of recovery attempts to delay period is as follow ~
```
1st - 3rd failure: No delay
4th failure: 30-second delay
5th failure: 1-minute delay
6th failure: 5-minute delay
7th failure: 15-minute delay
8th failure: 30-minute delay
9th failure: 45-minute delay
10th failure: 1-hour lockout
>10th failure: Incremental lockout (up to 1 day)
After 1 day(24 hr), its 24hr lockout on every attempt*
```

However, the delay values are not accurate due to the network latency. Hence, we will get the ratelimit delay value from the server and use it in the client side.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Changelog

<!--
THIS SECTION IS NO LONGER NEEDED.

The process for updating changelogs has changed. Please consult the "Updating changelogs" section of the Contributing doc for more.
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
